### PR TITLE
Fix: Cookies are now parsed from lowercase set-cookie header

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>khttp</groupId>
     <artifactId>khttp</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <name>khttp</name>
     <description>A HTTP request library for Kotlin.</description>
     <url>https://github.com/jkcclemens/khttp</url>

--- a/src/main/kotlin/khttp/responses/GenericResponse.kt
+++ b/src/main/kotlin/khttp/responses/GenericResponse.kt
@@ -33,7 +33,7 @@ class GenericResponse internal constructor(override val request: Request) : Resp
     internal companion object {
 
         internal val HttpURLConnection.cookieJar: CookieJar
-            get() = CookieJar(*this.headerFields.filter { it.key == "Set-Cookie" }.flatMap { it.value }.filter(String::isNotEmpty).map(::Cookie).toTypedArray())
+            get() = CookieJar(*this.headerFields.filter { it.key.equals("set-cookie", true) }.flatMap { it.value }.filter(String::isNotEmpty).map(::Cookie).toTypedArray())
 
         internal fun HttpURLConnection.forceMethod(method: String) {
             try {


### PR DESCRIPTION
I just ignore the case, since headers are not case sensitive in the first place and it is a mistake to assume case.

Closes #52 